### PR TITLE
Fix zettel path when creating hyperlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2023-04-07
+
+- Fix path for creating wiki links
+
 ## 2023-04-05
 
 - Add bash script to create PR from CHANGELOG.md

--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -104,12 +104,12 @@ autocmd FileType html setlocal shiftwidth=2 tabstop=2
 " Search for files in wiki
 command! -bang WikiSearch call fzf#vim#files('~/Dropbox/wiki', <bang>0)
 
-
+" Create a link to another file in the wiki
 function! WikiLink(line)
     let abs_path = substitute(a:line, './', $HOME.'/Dropbox/wiki/', '')
     let contents = readfile(abs_path)
     let title = substitute(contents[0], '^#\+\s*', '', '')
-    let rel_path = substitute(a:line, 'zettel/', '', '')
+    let rel_path = substitute(substitute(a:line, 'zettel/', '', ''), '.md', '', '')
     let wikilink = '[['.rel_path.'|'.title.']]'
 
     " Write link without text wrapping


### PR DESCRIPTION
```diff
diff --git a/CHANGELOG.md b/CHANGELOG.md
index 091a631..d282879 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2023-04-07
+
+- Fix path for creating wiki links
+
 ## 2023-04-05
 
 - Add bash script to create PR from CHANGELOG.md
```
