### PR TITLE
Disable atuin daemon to fix startup errors after reboot

### DIFF
--- a/atuin/config.toml
+++ b/atuin/config.toml
@@ -95,6 +95,4 @@ update_check = false
 
 # Daemon mode: background process manages history sync/writes for better performance
 [daemon]
-enabled = true
-# Use socket for IPC (faster than TCP for local daemon)
-socket_path = "/tmp/atuin.sock"
+enabled = false


### PR DESCRIPTION
## Summary
- Disable the atuin daemon in `atuin/config.toml` to fix "failed to connect to local atuin daemon" errors that occur after every reboot
- The daemon socket at `/tmp/atuin.sock` is cleared on macOS restart and nothing recreates it, so the daemon was broken on every fresh boot
- Since sync is disabled (local-only mode), the daemon provides negligible performance benefit

## Test plan
- [ ] Open a new terminal after reboot and confirm `atuin` commands work without errors