### PR TITLE
fix: restrict r_language_server to r/rmd filetypes only

### DIFF
--- a/nvim/lua/plugins/language.lua
+++ b/nvim/lua/plugins/language.lua
@@ -24,6 +24,20 @@ return {
     opts = { ensure_installed = { "prettier", "prettierd" } },
   },
   {
+    "neovim/nvim-lspconfig",
+    opts = {
+      servers = {
+        -- Prevent r_language_server from attaching to quarto files that don't
+        -- have an R project root, since mason-lspconfig maps it to quarto by
+        -- default and it errors on Python-only .qmd files.
+        r_language_server = {
+          root_markers = { "DESCRIPTION", "NAMESPACE", ".Rbuildignore", "*.Rproj" },
+          filetypes = { "r", "rmd" },
+        },
+      },
+    },
+  },
+  {
     "stevearc/conform.nvim",
     opts = {
       formatters_by_ft = {


### PR DESCRIPTION
## Summary

- mason-lspconfig maps r_language_server to quarto by default, causing INVALID_SERVER_MESSAGE errors when editing Python-only .qmd files
- Override filetypes to { "r", "rmd" } so the server only attaches to R files
- Add root_markers to further restrict attachment to directories with an R project root

## Test Plan

- [ ] Open a Python-only .qmd file and confirm no LSP errors in :messages
- [ ] Open an .R or .Rmd file and confirm r_language_server attaches correctly

Made with [Cursor](https://cursor.com)