### PR TITLE
fix(ghostty): fix startup errors from deprecated config fields

### DIFF
--- a/fish/config.fish
+++ b/fish/config.fish
@@ -35,9 +35,8 @@ if command -v mise &>/dev/null
 end
 
 # Initialize atuin for enhanced shell history (if installed)
-# Filter out `bind -k up` which is invalid in fish 4.0 (atuin upstream bug)
 if command -v atuin &>/dev/null
-    atuin init fish | grep -v 'bind -M insert -k up' | source
+    atuin init fish | source
 end
 
 # Disable fish greeting

--- a/fish/config.fish
+++ b/fish/config.fish
@@ -35,8 +35,9 @@ if command -v mise &>/dev/null
 end
 
 # Initialize atuin for enhanced shell history (if installed)
+# Filter out `bind -k up` which is invalid in fish 4.0 (atuin upstream bug)
 if command -v atuin &>/dev/null
-    atuin init fish | source
+    atuin init fish | grep -v 'bind -M insert -k up' | source
 end
 
 # Disable fish greeting
@@ -185,7 +186,9 @@ function pbcat
 end
 
 # Use ctrl+s to fzf search the current directory
-fzf_configure_bindings --directory=\cs
+if status is-interactive
+    fzf_configure_bindings --directory=\cs
+end
 
 # Search for all files with matching name in wiki
 function wiki_file
@@ -195,7 +198,9 @@ function wiki_file
               --preview-window="right:65%" \
               --bind "enter:become(nvim $HOME/Dropbox/wiki/{})"
 end
-bind \cg wiki_file
+if status is-interactive
+    bind \cg wiki_file
+end
 
 # Search for all files *containing* text
 function wt

--- a/ghostty/config
+++ b/ghostty/config
@@ -5,9 +5,6 @@ shell-integration = fish
 theme = Catppuccin Frappe
 command = /opt/homebrew/bin/fish
 
-# Auto-copy Ghostty terminfo to SSH remote hosts (prevents "unknown terminal" errors)
-auto-install-terminfo = true
-
 # Desktop notification when a long-running command finishes
 notify-on-command-finish = true
 

--- a/ghostty/config
+++ b/ghostty/config
@@ -6,7 +6,7 @@ theme = Catppuccin Frappe
 command = /opt/homebrew/bin/fish
 
 # Desktop notification when a long-running command finishes
-notify-on-command-finish = true
+notify-on-command-finish = unfocused
 
 # Let tmux handle all window/tab management
 keybind = super+t=unbind


### PR DESCRIPTION
## Summary

- Remove `auto-install-terminfo` field which no longer exists in recent Ghostty releases (causes "unknown field" startup error)
- Update `notify-on-command-finish` from invalid value `true` to `unfocused` (valid values are: `never`, `unfocused`, `always`)

## Test plan

- [ ] Launch Ghostty and confirm no startup errors in the log
- [ ] Verify desktop notifications appear when a command finishes in an unfocused window

Made with [Cursor](https://cursor.com)