### PR TITLE
Add automated encrypted daily backup for paperless-ngx

### DIFF
--- a/ansible/dotfiles.yml
+++ b/ansible/dotfiles.yml
@@ -71,6 +71,12 @@
         - paperless
         - never
 
+    - name: Include paperless backup setup tasks
+      include_tasks: tasks/paperless_backup.yml
+      tags:
+        - paperless-backup
+        - never
+
     - name: Include dotfile linking tasks
       include_tasks: tasks/link_files.yml
       tags:

--- a/ansible/tasks/paperless_backup.yml
+++ b/ansible/tasks/paperless_backup.yml
@@ -1,0 +1,40 @@
+---
+- name: Install restic via Homebrew
+  community.general.homebrew:
+    name: restic
+    state: present
+
+- name: Create paperless backup staging directory
+  ansible.builtin.file:
+    path: "{{ ansible_user_dir }}/.paperless-backup-staging"
+    state: directory
+    mode: "0700"
+
+- name: Copy paperless backup launchd plist
+  ansible.builtin.copy:
+    src: "{{ ansible_user_dir }}/.dotfiles/paperless-ngx/uk.me.michaelbarton.paperless-backup.plist"
+    dest: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-backup.plist"
+    mode: "0644"
+
+- name: Load paperless backup launch agent
+  ansible.builtin.command:
+    cmd: launchctl load "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-backup.plist"
+  args:
+    creates: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-backup.plist"
+
+# One-time manual setup required (run these once before first backup):
+#
+#   security add-generic-password -a $USER -s paperless-backup-b2-id -w '<keyID>'
+#   security add-generic-password -a $USER -s paperless-backup-b2-key -w '<applicationKey>'
+#   security add-generic-password -a $USER -s paperless-backup-restic-pw -w '<strong-random-password>'
+#
+# IMPORTANT: Also save the restic password in 1Password — lose it and backups are unrecoverable.
+#
+# Then initialise the restic repo once:
+#   set -x B2_ACCOUNT_ID (security find-generic-password -a $USER -s paperless-backup-b2-id -w)
+#   set -x B2_ACCOUNT_KEY (security find-generic-password -a $USER -s paperless-backup-b2-key -w)
+#   set -x RESTIC_PASSWORD (security find-generic-password -a $USER -s paperless-backup-restic-pw -w)
+#   restic -r b2:mb-paperless-backup:paperless init
+#
+# Also restart the paperless stack to pick up the new volume mount:
+#   docker compose -f ~/.dotfiles/paperless-ngx/docker-compose.yml up -d

--- a/paperless-ngx/backup.sh
+++ b/paperless-ngx/backup.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+LOG_FILE="$HOME/Library/Logs/paperless-backup.log"
+STAGING_DIR="$HOME/.paperless-backup-staging"
+COMPOSE_FILE="$HOME/.dotfiles/paperless-ngx/docker-compose.yml"
+
+log() {
+    echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+log "Starting paperless backup"
+
+export B2_ACCOUNT_ID
+B2_ACCOUNT_ID=$(security find-generic-password -a "$USER" -s paperless-backup-b2-id -w)
+export B2_ACCOUNT_KEY
+B2_ACCOUNT_KEY=$(security find-generic-password -a "$USER" -s paperless-backup-b2-key -w)
+export RESTIC_PASSWORD
+RESTIC_PASSWORD=$(security find-generic-password -a "$USER" -s paperless-backup-restic-pw -w)
+
+log "Clearing staging directory"
+mkdir -p "$STAGING_DIR"
+rm -rf "${STAGING_DIR:?}"/*
+
+log "Running paperless document_exporter"
+/Applications/Docker.app/Contents/Resources/bin/docker compose -f "$COMPOSE_FILE" exec -T webserver document_exporter -na -nt -f /usr/src/paperless/backup
+
+log "Running restic backup"
+restic -r b2:mb-paperless-backup:paperless backup "$STAGING_DIR"
+
+log "Pruning old snapshots"
+restic -r b2:mb-paperless-backup:paperless forget --keep-daily 7 --keep-weekly 2 --keep-monthly 2 --prune
+
+log "Paperless backup complete"

--- a/paperless-ngx/docker-compose.yml
+++ b/paperless-ngx/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - /Users/michaelbarton/.paperless:/usr/src/paperless/media:rw
       - /Users/michaelbarton/Downloads:/usr/src/paperless/export:rw
       - /Users/michaelbarton/Documents/consume:/usr/src/paperless/consume:rw
+      - /Users/michaelbarton/.paperless-backup-staging:/usr/src/paperless/backup:rw
     env_file: docker-compose.env
     environment:
       PAPERLESS_REDIS: redis://broker:6379

--- a/paperless-ngx/uk.me.michaelbarton.paperless-backup.plist
+++ b/paperless-ngx/uk.me.michaelbarton.paperless-backup.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>uk.me.michaelbarton.paperless-backup</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/michaelbarton/.dotfiles/paperless-ngx/backup.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>3</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/michaelbarton/Library/Logs/paperless-backup.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/michaelbarton/Library/Logs/paperless-backup.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

- Adds `paperless-ngx/backup.sh` — pulls secrets from macOS Keychain, runs `document_exporter` inside the container, uploads to Backblaze B2 via restic (encrypted, deduplicated), prunes to 7 daily / 2 weekly / 2 monthly snapshots
- Adds `paperless-ngx/uk.me.michaelbarton.paperless-backup.plist` — launchd agent firing daily at 03:00 (`RunAtLoad false`)
- Adds volume mount `~/.paperless-backup-staging:/usr/src/paperless/backup` to `docker-compose.yml`
- Adds `ansible/tasks/paperless_backup.yml` — installs restic, staging dir, plist; tagged `paperless-backup` / `never` so it only runs on explicit request and won't affect other machines
- Updates `ansible/dotfiles.yml` to include the new task

## Test plan

- [x] Restic repo initialised on Backblaze B2 (`restic init`)
- [x] Full backup ran successfully end-to-end (418 documents, 320 MiB uploaded, snapshot `9bbec337` saved)
- [x] Prune ran cleanly after backup
- [ ] Install launchd agent: `ansible-playbook ansible/dotfiles.yml --tags paperless-backup`
- [ ] Verify agent loaded: `launchctl list | grep paperless-backup`

## One-time setup (already done)

Secrets stored in macOS Keychain — see comments in `ansible/tasks/paperless_backup.yml` for the `security add-generic-password` commands and `restic init` steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)