### PR TITLE
fix(python): bump template pytest to ^9.0.3 for tmpdir vulnerability

### DIFF
--- a/python/cookiecutter/scratch-python-template/{{cookiecutter.timestamp}}__{{cookiecutter.project_name}}/pyproject.toml
+++ b/python/cookiecutter/scratch-python-template/{{cookiecutter.timestamp}}__{{cookiecutter.project_name}}/pyproject.toml
@@ -14,7 +14,7 @@ edx-lint = "^5.3.6"
 mypy = "^1.8.0"
 pandas-stubs = "^2.2.0.240218"
 pydocstyle = "^6.3.0"
-pytest = "^8.0.0"
+pytest = "^9.0.3"
 ruff = "^0.8.0"
 
 [build-system]


### PR DESCRIPTION
Resolves [Dependabot alert #1](https://github.com/michaelbarton/dotfiles/security/dependabot/1) (moderate): pytest < 9.0.3 has vulnerable tmpdir handling.

The cookiecutter template pinned `pytest = "^8.0.0"`, which can never resolve to the patched 9.0.3. Bumped to `^9.0.3`; the template already requires `python = "^3.10"`, which pytest 9 supports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)