### PR TITLE
Auto-start paperless on login and fix data/media mount overlap

### DIFF
--- a/ansible/dotfiles.yml
+++ b/ansible/dotfiles.yml
@@ -18,6 +18,9 @@
     python_version: "3.11" # Adjust this to your preferred Python version
     dotfiles_dir: "{{ ansible_env.HOME }}/.dotfiles"
     config_dir: "{{ ansible_user_dir }}/.config"
+    # The one machine this repo treats as "home" — gates tasks that must
+    # never run on a work computer (e.g. paperless auto-start).
+    personal_hostname: Michaels-MacBook-Air
 
   tasks:
     - name: Create necessary directories

--- a/ansible/tasks/paperless.yml
+++ b/ansible/tasks/paperless.yml
@@ -1,15 +1,35 @@
 ---
-- name: Create paperless data directory
+- name: Create paperless data directories
   ansible.builtin.file:
-    path: "{{ ansible_user_dir }}/.paperless"
+    path: "{{ ansible_user_dir }}/.paperless/{{ item }}"
     state: directory
     mode: "0755"
+  loop:
+    - data
+    - media
 
 - name: Create paperless consume directory
   ansible.builtin.file:
     path: "{{ ansible_user_dir }}/Documents/consume"
     state: directory
     mode: "0755"
+
+# The paperless auto-start agent is host-specific: it must only run on this
+# personal machine, never on a work computer that happens to check out these
+# dotfiles.
+- name: Copy paperless start launchd plist
+  ansible.builtin.copy:
+    src: "{{ ansible_user_dir }}/.dotfiles/paperless-ngx/uk.me.michaelbarton.paperless-start.plist"
+    dest: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
+    mode: "0644"
+  when: ansible_hostname == "Michaels-MacBook-Air"
+
+- name: Load paperless start launch agent
+  ansible.builtin.command:
+    cmd: launchctl load "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
+  args:
+    creates: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
+  when: ansible_hostname == "Michaels-MacBook-Air"
 
 - name: Check if paperless env file exists
   ansible.builtin.stat:

--- a/ansible/tasks/paperless.yml
+++ b/ansible/tasks/paperless.yml
@@ -17,19 +17,20 @@
 # The paperless auto-start agent is host-specific: it must only run on this
 # personal machine, never on a work computer that happens to check out these
 # dotfiles.
-- name: Copy paperless start launchd plist
-  ansible.builtin.copy:
-    src: "{{ ansible_user_dir }}/.dotfiles/paperless-ngx/uk.me.michaelbarton.paperless-start.plist"
-    dest: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
-    mode: "0644"
-  when: ansible_hostname == "Michaels-MacBook-Air"
+- name: Install paperless start launch agent
+  when: ansible_hostname == personal_hostname
+  block:
+    - name: Copy paperless start launchd plist
+      ansible.builtin.copy:
+        src: "{{ ansible_user_dir }}/.dotfiles/paperless-ngx/uk.me.michaelbarton.paperless-start.plist"
+        dest: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
+        mode: "0644"
 
-- name: Load paperless start launch agent
-  ansible.builtin.command:
-    cmd: launchctl load "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
-  args:
-    creates: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
-  when: ansible_hostname == "Michaels-MacBook-Air"
+    - name: Load paperless start launch agent
+      ansible.builtin.command:
+        cmd: launchctl load "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
+      args:
+        creates: "{{ ansible_user_dir }}/Library/LaunchAgents/uk.me.michaelbarton.paperless-start.plist"
 
 - name: Check if paperless env file exists
   ansible.builtin.stat:

--- a/paperless-ngx/docker-compose.yml
+++ b/paperless-ngx/docker-compose.yml
@@ -47,8 +47,8 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - /Users/michaelbarton/.paperless:/usr/src/paperless/data:rw
-      - /Users/michaelbarton/.paperless:/usr/src/paperless/media:rw
+      - /Users/michaelbarton/.paperless/data:/usr/src/paperless/data:rw
+      - /Users/michaelbarton/.paperless/media:/usr/src/paperless/media:rw
       - /Users/michaelbarton/Downloads:/usr/src/paperless/export:rw
       - /Users/michaelbarton/Documents/consume:/usr/src/paperless/consume:rw
       - /Users/michaelbarton/.paperless-backup-staging:/usr/src/paperless/backup:rw

--- a/paperless-ngx/start.sh
+++ b/paperless-ngx/start.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+LOG_FILE="$HOME/Library/Logs/paperless-start.log"
+COMPOSE_FILE="$HOME/.dotfiles/paperless-ngx/docker-compose.yml"
+DOCKER="/Applications/Docker.app/Contents/Resources/bin/docker"
+
+log() {
+    echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*" | tee -a "$LOG_FILE"
+}
+
+log "Waiting for Docker to be ready"
+for i in $(seq 1 60); do
+    if "$DOCKER" info >/dev/null 2>&1; then
+        break
+    fi
+    sleep 5
+done
+
+if ! "$DOCKER" info >/dev/null 2>&1; then
+    log "Docker did not become ready in time, giving up"
+    exit 1
+fi
+
+log "Starting paperless stack"
+"$DOCKER" compose -f "$COMPOSE_FILE" up -d
+
+log "Paperless stack started"

--- a/paperless-ngx/uk.me.michaelbarton.paperless-start.plist
+++ b/paperless-ngx/uk.me.michaelbarton.paperless-start.plist
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>uk.me.michaelbarton.paperless-start</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/michaelbarton/.dotfiles/paperless-ngx/start.sh</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/Users/michaelbarton/Library/Logs/paperless-start.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/michaelbarton/Library/Logs/paperless-start.log</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Paperless's containers died when the Docker Desktop VM last restarted and never came back — `restart: unless-stopped` doesn't refire in that case, and nothing was polling to bring the stack back up.
- Adds a LaunchAgent that waits for Docker and runs `docker compose up -d` on login, gated to `Michaels-MacBook-Air` so it's never installed via ansible on a work computer.
- Fixes `docker-compose.yml` mounting the same host directory to both `/data` and `/media`, which made paperless's sanity checker flag data files (db.sqlite3, search index, logs, classifier model) as orphaned media on every run. Split into separate `data/` and `media/` subdirectories.

## Test plan
- [x] Ran the new `start.sh` manually and via the loaded LaunchAgent — waits for Docker, brings up all 4 containers, confirmed `docker ps` shows them healthy.
- [x] Migrated this machine's live `~/.paperless` directory into `data/`/`media/` subdirs, restarted the stack, confirmed `http://localhost:8000` responds and the login page loads.
- [x] Ran `document_sanity_checker` manually post-migration: `Sanity checker detected no issues.` (previously logged ~30 orphaned-file warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)