### PR TITLE
Add healthchecks.io dead-man's-switch to paperless backup

### DIFF
--- a/ansible/tasks/paperless_backup.yml
+++ b/ansible/tasks/paperless_backup.yml
@@ -29,6 +29,16 @@
 #
 # IMPORTANT: Also save the restic password in 1Password — lose it and backups are unrecoverable.
 #
+# Optional but recommended: a healthchecks.io dead-man's-switch so a silently
+# broken or unscheduled backup job (e.g. the LaunchAgent never getting loaded)
+# gets flagged, not just script errors. Create a free check at
+# https://healthchecks.io with a 24h period matching the daily 3am schedule
+# (a few hours of grace time), then store its ping URL:
+#
+#   security add-generic-password -a $USER -s paperless-backup-healthcheck-url -w 'https://hc-ping.com/<uuid>'
+#
+# If this isn't set, backup.sh just skips the ping and runs as before.
+#
 # Then initialise the restic repo once:
 #   set -x B2_ACCOUNT_ID (security find-generic-password -a $USER -s paperless-backup-b2-id -w)
 #   set -x B2_ACCOUNT_KEY (security find-generic-password -a $USER -s paperless-backup-b2-key -w)

--- a/paperless-ngx/backup.sh
+++ b/paperless-ngx/backup.sh
@@ -11,6 +11,19 @@ log() {
     echo "[$(date '+%Y-%m-%dT%H:%M:%S')] $*" | tee -a "$LOG_FILE"
 }
 
+HEALTHCHECK_PING_URL=$(security find-generic-password -a "$USER" -s paperless-backup-healthcheck-url -w 2>/dev/null || true)
+
+ping_healthcheck() {
+    [ -z "$HEALTHCHECK_PING_URL" ] && return 0
+    curl -fsS -m 10 --retry 3 -o /dev/null "${HEALTHCHECK_PING_URL}${1:-}" || true
+}
+
+on_error() {
+    log "Paperless backup failed"
+    ping_healthcheck /fail
+}
+trap on_error ERR
+
 log "Starting paperless backup"
 
 export B2_ACCOUNT_ID
@@ -34,3 +47,4 @@ log "Pruning old snapshots"
 restic -r b2:mb-paperless-backup:paperless forget --keep-daily 7 --keep-weekly 2 --keep-monthly 2 --prune
 
 log "Paperless backup complete"
+ping_healthcheck


### PR DESCRIPTION
## Summary
- We just found the daily paperless backup LaunchAgent was never loaded on this machine — the job silently didn't run for 62 days with nothing to flag it, since there was no failed run to notice, just no run at all.
- `backup.sh` now pings a [healthchecks.io](https://healthchecks.io) check on success, and its `/fail` endpoint (via an `ERR` trap) if any step fails.
- If the scheduled ping doesn't arrive (crashed run, unloaded LaunchAgent, machine off, etc.), healthchecks.io raises the alert externally — this is what actually catches the "job never ran" failure mode, which a local "notify on script error" never would have.
- The ping URL is optional, read from Keychain (`paperless-backup-healthcheck-url`); if unset, `backup.sh` just skips the ping and behaves exactly as before.

## Test plan
- [x] `bash -n backup.sh` — syntax check passes.
- [x] Isolated the trap + ping logic and verified: a failing step triggers the `ERR` trap, logs the failure, and best-effort pings `/fail` without the ping itself being able to crash the script (`|| true`).
- [x] Verified the success path calls `ping_healthcheck` after "Paperless backup complete" and exits 0.

## Follow-up (manual, one-time)
Documented in `ansible/tasks/paperless_backup.yml`: create a free check at healthchecks.io with a 24h period (~a few hours grace) matching the daily 3am schedule, then:
```
security add-generic-password -a $USER -s paperless-backup-healthcheck-url -w 'https://hc-ping.com/<uuid>'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)