### PR TITLE
Pin ruff to 0.15.5 in Makefile to stop silent CI drift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,15 +13,15 @@ apply:
 fmt:
 	@if [ -n "$(YAML_FILES)" ]; then npx --loglevel error --yes prettier --write $(YAML_FILES); fi
 	@if [ -n "$(MARKDOWN_FILES)" ]; then uvx --with mdformat-gfm --with mdformat-frontmatter mdformat --wrap 80 --number $(MARKDOWN_FILES); fi
-	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff format --line-length=100 $(PYTHON_FILES); fi
-	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff check --fix --line-length=100 $(PYTHON_FILES); fi
+	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff@0.15.5 format --line-length=100 $(PYTHON_FILES); fi
+	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff@0.15.5 check --fix --line-length=100 $(PYTHON_FILES); fi
 	@if [ -n "$(LUA_FILES)" ]; then npx --loglevel error --yes @johnnymorganz/stylua-bin -- $(LUA_FILES); fi
 
 fmt_check:
 	@if [ -n "$(YAML_FILES)" ]; then npx --loglevel error --yes prettier --check $(YAML_FILES); fi
 	@if [ -n "$(MARKDOWN_FILES)" ]; then uvx --with mdformat-gfm --with mdformat-frontmatter mdformat --check --wrap 80 --number $(MARKDOWN_FILES); fi
-	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff format --check --line-length=100 $(PYTHON_FILES); fi
-	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff check --line-length=100 $(PYTHON_FILES); fi
+	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff@0.15.5 format --check --line-length=100 $(PYTHON_FILES); fi
+	@if [ -n "$(PYTHON_FILES)" ]; then uvx ruff@0.15.5 check --line-length=100 $(PYTHON_FILES); fi
 	@if [ -n "$(LUA_FILES)" ]; then npx --loglevel error --yes @johnnymorganz/stylua-bin --check -- $(LUA_FILES); fi
 
 nvim-health:


### PR DESCRIPTION
## Summary
- The formatting-check CI job started failing on unrelated PRs (#101, #102) that never touched Python at all — turned out to be `Makefile`'s `uvx ruff ...` calls fetching latest ruff on every run with no version pin.
- Bisected: ruff 0.16.0 expanded its default rule set and started flagging 73 pre-existing issues across 15 files unrelated to any current PR (e.g. `zettel/template_today.py`, `dbt/dbt_analyse.py`). 0.15.5 is the last version that passes cleanly on current repo content.
- Pins both `ruff format` and `ruff check` invocations (in `fmt` and `fmt_check`) to `0.15.5` so CI results depend only on what a PR actually changes. Upgrading ruff later — and fixing whatever it newly flags — becomes a deliberate, isolated change instead of silent breakage on an unrelated PR.

## Test plan
- [x] `make fmt_check` passes cleanly on current `master` content with the pin in place (previously failed with "Found 73 errors").
- [x] Confirmed via bisection across ruff 0.9.0–0.16.2 that 0.15.5 is the newest clean version and 0.16.0 is where it breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)