### PR TITLE
Add mdformat-gfm to the nvim venv so conform.nvim can format tables

### DIFF
--- a/ansible/tasks/neovim.yml
+++ b/ansible/tasks/neovim.yml
@@ -19,7 +19,7 @@
     cmd: >
       uv pip install --python {{ venv_path }}/nvim/bin/python
       codespell dap-python debugpy isort mdformat mdformat-frontmatter
-      neovim pynvim "ruff=={{ ruff_version }}" yamllint
+      mdformat-gfm neovim pynvim "ruff=={{ ruff_version }}" yamllint
   register: nvim_uv_pip
   changed_when: "'Installed' in nvim_uv_pip.stdout or 'Updated' in nvim_uv_pip.stdout"
 


### PR DESCRIPTION
## Summary
- conform.nvim's markdown formatter resolves `mdformat` from `~/.venvs/nvim/bin` (added to `PATH` in `nvim/lua/config/options.lua`), which only had `mdformat` and `mdformat-frontmatter` installed.
- Without `mdformat-gfm`, mdformat's core CommonMark parser doesn't recognize pipe tables, so autoformatting on save collapsed tables into one paragraph and rewrapped them, destroying the table.
- `make fmt`/`make fmt_check` already pulled in `mdformat-gfm` via `uvx --with`, so only the nvim path was affected — reproduced with the exact venv nvim uses, confirmed the fix restores correct table formatting.

## Test plan
- [x] Reproduced: ran `~/.venvs/nvim/bin/python -m mdformat --wrap 80 --number` on a file with a table — table collapsed into a rewrapped paragraph.
- [x] Installed `mdformat-gfm` into `~/.venvs/nvim` locally and re-ran the same command — table formatted correctly.
- [ ] Re-provision via ansible (`ansible-playbook ...` / your usual bootstrap) on other machines so the venv there also picks up `mdformat-gfm`.

https://claude.ai/code/session_01UiGb4Syd7eRtYyPnynTuiZ