### PR TITLE
Disable delta side-by-side diffs inside lazygit only

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -155,7 +155,7 @@
 
 [delta]
     navigate = true
-    side-by-side = true
+    features = side-by-side
     line-numbers = true
     detect-dark-light = always
     # OSC8 hyperlinks: file paths in diffs become clickable in Ghostty
@@ -179,6 +179,12 @@
     hunk-header-style = yellow dim
     file-decoration-style = none
     commit-decoration-style = none
+
+# Named feature so it can be disabled per-invocation with --features=
+# (used by lazygit's diffRenderers, which finds side-by-side confusing
+# in its narrower panel)
+[delta "side-by-side"]
+    side-by-side = true
 
 [diff]
 	tool = difftastic

--- a/lazygit/config.yml
+++ b/lazygit/config.yml
@@ -8,18 +8,19 @@ gui:
   # Better commit message length
   commitLength:
     show: true
-
 os:
   # Open files in existing nvim instance when inside a nvim terminal
   editPreset: "nvim-remote"
-
 git:
   # Auto-fetch every 60 seconds
   autoFetch: true
   autoRefresh: true
-  # Use delta for diffs with correct panel width for side-by-side
-  pagers:
-    - pager: delta --paging=never --width={{columnWidth}}
+  # Use delta for diffs, forced to unified layout: side-by-side stays on
+  # for normal terminal `git diff` (see [delta "side-by-side"] in
+  # gitconfig) but is confusing in lazygit's narrower panel, so it's
+  # disabled here via --features=
+  diffRenderers:
+    - command: delta --paging=never --width={{columnWidth}} --features=
   # Use difftastic when pressing 'd' on a file (respects diff.external in gitconfig)
   useExternalDiffGitConfig: true
   # Better merge behavior
@@ -33,7 +34,6 @@ git:
     signOff: false
     autoWrapCommitMessage: true
     autoWrapWidth: 72
-
 # Custom commands for common workflows
 customCommands:
   - key: "<c-p>"
@@ -44,11 +44,9 @@ customCommands:
     description: "View PR in browser"
     context: "global"
     command: "gh pr view --web"
-
 # Confirmations
 confirmOnQuit: false
 quitOnTopLevelReturn: true
-
 # Key bindings (vim-style)
 keybinding:
   universal:
@@ -76,6 +74,5 @@ keybinding:
     markCommitAsFixup: "f"
     createFixupCommit: "F"
     rewordCommit: "w"
-
 # Start in commits view (change to 'files' if you prefer)
 startupPopupVersion: 5


### PR DESCRIPTION
## Summary
- lazygit's `diffRenderers` inherited delta's global `side-by-side = true`, which is confusing in lazygit's narrower panel
- Moved side-by-side into a named delta feature (`[delta "side-by-side"]`) that's active by default, so normal terminal `git diff`/`git dft` keep the two-column layout
- lazygit's delta command now passes `--features=` to opt out of that feature per-invocation, rendering unified diffs there instead
- Also carries the pending `pagers:` -> `diffRenderers:` lazygit config key rename this change builds on

## Test plan
- [x] `make fmt_check` passes
- [x] Verified in an isolated `HOME`/`XDG_CONFIG_HOME` sandbox that `--features=` correctly drops the `side-by-side` feature while leaving other delta options (line-numbers, hyperlinks, colors) active
- [x] Confirmed with the real gitconfig that plain `git diff | delta` still renders side-by-side
- [ ] Open lazygit and eyeball a diff panel to confirm unified layout (manual, not done from this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)